### PR TITLE
bug fix when encoding list + use mpk:*use-null*

### DIFF
--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -179,9 +179,10 @@ We return a `tr-timestamp' carrying the number of millisecs since epoch
 
 (defun decode* (data &optional (cache nil) (map-key? nil))
   (let ((cl:*read-default-float-format* 'long-float))
-    (if (eq *encode-target* 'JSON)
-        (decode (jzon:parse data) cache map-key?)
-        (decode (mpk:decode data) cache map-key?))))
+    (if (eq *encode-target* 'MSGPACK)
+        (let ((mpk:*use-null* t))
+          (decode (mpk:decode data) cache map-key?))
+        (decode (jzon:parse data) cache map-key?))))
 
 (defun decode-json (data &optional (cache nil) (map-key? nil))
   (let ((*encode-target* 'JSON))

--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -139,8 +139,8 @@
 (defun encode-list (data cache map-key?)
   (declare (cons data))
   (list (cache-write cache "~#list" nil)
-        (mapcar (lambda (x) (encode x cache map-key?))
-                data)))
+        (let ((l (mapcar (lambda (x) (encode x cache map-key?)) data)))
+          (make-array (length l) :initial-contents l))))
 
 (defun special-numberp (data)
   (member data (list 'INF '-INF 'NAN)))

--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -138,10 +138,9 @@
 
 (defun encode-list (data cache map-key?)
   (declare (cons data))
-  (when (car data)
-    (list (cache-write cache "~#list" nil)
-          (mapcar (lambda (x) (encode x cache map-key?))
-                  data))))
+  (list (cache-write cache "~#list" nil)
+        (mapcar (lambda (x) (encode x cache map-key?))
+                data)))
 
 (defun special-numberp (data)
   (member data (list 'INF '-INF 'NAN)))
@@ -253,4 +252,3 @@
 (defun encode-mp (data &optional (cache nil) (map-key? nil))
   (let ((*encode-target* 'MSGPACK))
     (encode* data cache map-key?)))
-


### PR DESCRIPTION
* fixed a bug in `encode-list` when the first element is `nil`
* moved to using cl-messagepack:*use-null*  (see [this PR](https://github.com/mbrezu/cl-messagepack/pull/24))